### PR TITLE
fix(tier4_simulation_msgs): fix signedness mismatch in UserDefinedValueType

### DIFF
--- a/tier4_simulation_msgs/msg/UserDefinedValueType.msg
+++ b/tier4_simulation_msgs/msg/UserDefinedValueType.msg
@@ -6,4 +6,4 @@ int8 STRING=4
 int8 UNSIGNED_INT=5
 int8 UNSIGNED_SHORT=6
 
-uint8 data
+int8 data


### PR DESCRIPTION
## Related Links

<!-- Please write related links to GitHub/Jira/Slack/etc. -->

## Description

Fix a type mismatch in `UserDefinedValueType.msg`: the constants are declared as `int8` but the `data` field was declared as `uint8`. This changes the field type to `int8` to match the constants.

```diff
-uint8 data
+int8 data
```

All other enum-style messages in this repository (e.g., `Module.msg`, `State.msg`, `Command.msg`, `Shape.msg`) consistently match the field type to the constant type. This PR aligns `UserDefinedValueType.msg` with that convention.

## Remarks

This is a type-only change with no functional impact for the current constant values (0–6), but it corrects the signedness mismatch for consistency and correctness.

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Code is properly formatted
- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code is properly formatted
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets
- [ ] Write [release notes][release-notes]

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[release-notes]: https://tier4.atlassian.net/wiki/spaces/AIP/pages/563774416
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute